### PR TITLE
PS/GAIA-371 remove default when gpt is passed

### DIFF
--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -34,9 +34,7 @@ async def chat_completions(
         ),
     ],
 ):
-    if chat_request.model.lower().startswith("gpt-"):
-        chat_request.model = DEFAULT_MODEL
-
+    
     # Exception will be raised if model not supported.
     model = BedrockModel()
     model.validate(chat_request)


### PR DESCRIPTION
This change was a simple one to remove the check on in the chat.py file to default to the DEFAULT_MODEL when any model name containing gpt was passed.