### PR TITLE
Check max_completion_tokens too

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -392,9 +392,12 @@ class BedrockModel(BaseChatModel):
         # Base inference parameters.
         inference_config = {
             "temperature": chat_request.temperature,
-            "maxTokens": chat_request.max_tokens,
             "topP": chat_request.top_p,
         }
+        max_tokens = (
+            chat_request.max_completion_tokens if chat_request.max_completion_tokens else chat_request.max_tokens
+        )
+        inference_config["maxTokens"] = max_tokens
 
         if chat_request.stop is not None:
             stop = chat_request.stop


### PR DESCRIPTION
There is a discrepancy between how OpenAI and Bedrock specify `maxTokens`.

`max_tokens` is deprecated in OpenAI; they recommend using `max_completion_tokens` instead. (More details available on [their website](https://platform.openai.com/docs/guides/reasoning?api-mode=chat)).

However, Bedrock uses `maxTokens` in its [inference configuration](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html). This setting is used across all models supported by Bedrock.

The current gateway implementation ignores `max_completion_tokens` __unless__ another input property called `reasoning_effort` is provided. But providing that specifies an additional Bedrock request property `additionalModelRequestFields`, which is supposed to be used [only for model-specific properties](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_GenerationConfiguration.html) that are outside of what Bedrock provides an abstraction for.

Rather than rely on a deprecated property, or add additional complexity to our agents that interact with the LLM, this PR will instead check both `max_completion_tokens` __and__ `maxTokens` when setting Bedrock's `maxTokens`. __Note:__ this is what the gateway proxy already does when `reasoning_effort` is also specified.
